### PR TITLE
Addresses Issues #40

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# This is a Fork for Personal Experimental Development of the Project
+-----------
 # hass-sunpower
 Home Assistant SunPower Integration using the local installer ethernet interface.
 

--- a/custom_components/sunpower/const.py
+++ b/custom_components/sunpower/const.py
@@ -78,7 +78,7 @@ METER_SENSORS = {
     "METER_L12_V": ["v12_v", "Supply Volts", ELECTRIC_POTENTIAL_VOLT, "mdi:flash",
                     DEVICE_CLASS_VOLTAGE, STATE_CLASS_MEASUREMENT],
     "METER_TO_GRID": ["neg_ltea_3phsum_kwh", "KWH To Grid", ENERGY_KILO_WATT_HOUR, "mdi:flash",
-                      DEVICE_CLASS_ENERGY, STATE_CLASS_TOTAL_INCREASING],
+                      DEVICE_CLASS_ENERGY, STATE_CLASS_TOTAL],
     "METER_TO_HOME": ["pos_ltea_3phsum_kwh", "KWH To Home", ENERGY_KILO_WATT_HOUR, "mdi:flash",
                       DEVICE_CLASS_ENERGY, STATE_CLASS_TOTAL_INCREASING]
 }

--- a/custom_components/sunpower/const.py
+++ b/custom_components/sunpower/const.py
@@ -53,7 +53,7 @@ METER_SENSORS = {
         "Lifetime Power",
         ENERGY_KILO_WATT_HOUR,
         "mdi:flash",
-        DEVICE_CLASS_ENERGY, STATE_CLASS_TOTAL_INCREASING,
+        DEVICE_CLASS_ENERGY, STATE_CLASS_TOTAL,
     ],
     "METER_KW": ["p_3phsum_kw", "Power", POWER_KILO_WATT, "mdi:flash",
                  DEVICE_CLASS_POWER, STATE_CLASS_MEASUREMENT],


### PR DESCRIPTION
The 'State_Class_*' has been updated for "Meter_to_Grid" & "Meter_net_KWH" to allow for negative values. Changed from 'STATE_CLASS_TOTAL_INCREASING' to 'STATE_CLASS_TOTAL'.

Correction for - lifetime_power from integration sunpower has state class total_increasing, but its state is negative.

I have run this updated code on my test instance for 48 hours without issue, with several HS Restarts & atleast 1 HA Upgrade (2023-2-3 to 2023-2-4 most recently) and still running the updated code.