### PR TITLE
change to new units system

### DIFF
--- a/custom_components/sunpower/const.py
+++ b/custom_components/sunpower/const.py
@@ -1,15 +1,15 @@
 """Constants for the sunpower integration."""
 from homeassistant.const import (
-    TIME_SECONDS,
-    DATA_KILOBYTES,
-    FREQUENCY_HERTZ,
-    ENERGY_KILO_WATT_HOUR,
-    POWER_KILO_WATT,
-    POWER_VOLT_AMPERE,
-    PERCENTAGE,
-    ELECTRIC_POTENTIAL_VOLT,
-    ELECTRIC_CURRENT_AMPERE,
-    TEMP_CELSIUS,
+    UnitOfEnergy,
+    UnitOfPower,
+    UnitOfApparentPower,
+    UnitOfFrequency,
+    UnitOfTime,
+    UnitOfInformation,
+    UnitOfElectricPotential,
+    UnitOfElectricCurrent,
+    UnitOfTemperature,
+    PERCENTAGE
 )
 
 from homeassistant.components.sensor import SensorStateClass, SensorDeviceClass
@@ -36,42 +36,42 @@ INVERTER_STATE = "STATE"
 WORKING_STATE = "working"
 
 METER_SENSORS = {
-    "METER_FREQUENCY": ["freq_hz", "Frequency", FREQUENCY_HERTZ, "mdi:flash",
+    "METER_FREQUENCY": ["freq_hz", "Frequency", UnitOfFrequency.HERTZ, "mdi:flash",
                         None, SensorStateClass.MEASUREMENT],
     "METER_NET_KWH": [
         "net_ltea_3phsum_kwh",
         "Lifetime Power",
-        ENERGY_KILO_WATT_HOUR,
+        UnitOfEnergy.KILO_WATT_HOUR,
         "mdi:flash",
         SensorDeviceClass.ENERGY, SensorStateClass.TOTAL,
     ],
-    "METER_KW": ["p_3phsum_kw", "Power", POWER_KILO_WATT, "mdi:flash",
+    "METER_KW": ["p_3phsum_kw", "Power", UnitOfPower.KILO_WATT, "mdi:flash",
                  SensorDeviceClass.POWER, SensorStateClass.MEASUREMENT],
-    "METER_VAR": ["q_3phsum_kvar", "KVA Reactive", POWER_VOLT_AMPERE, "mdi:flash",
+    "METER_VAR": ["q_3phsum_kvar", "KVA Reactive", UnitOfApparentPower.VOLT_AMPERE, "mdi:flash",
                   None, SensorStateClass.MEASUREMENT],
-    "METER_VA": ["s_3phsum_kva", "KVA Apparent", POWER_VOLT_AMPERE, "mdi:flash",
+    "METER_VA": ["s_3phsum_kva", "KVA Apparent", UnitOfApparentPower.VOLT_AMPERE, "mdi:flash",
                  None, SensorStateClass.MEASUREMENT],
     "METER_POWER_FACTOR": ["tot_pf_rto", "Power Factor", PERCENTAGE, "mdi:flash",
                            SensorDeviceClass.POWER_FACTOR, SensorStateClass.MEASUREMENT],
-    "METER_L1_A": ["i1_a", "Leg 1 Amps", ELECTRIC_CURRENT_AMPERE, "mdi:flash",
+    "METER_L1_A": ["i1_a", "Leg 1 Amps", UnitOfElectricCurrent.AMPERE, "mdi:flash",
                    SensorDeviceClass.CURRENT, SensorStateClass.MEASUREMENT],
-    "METER_A": ["i_a", "Amps", ELECTRIC_CURRENT_AMPERE, "mdi:flash",
+    "METER_A": ["i_a", "Amps", UnitOfElectricCurrent.AMPERE, "mdi:flash",
                    SensorDeviceClass.CURRENT, SensorStateClass.MEASUREMENT],
-    "METER_L2_A": ["i2_a", "Leg 2 Amps", ELECTRIC_CURRENT_AMPERE, "mdi:flash",
+    "METER_L2_A": ["i2_a", "Leg 2 Amps", UnitOfElectricCurrent.AMPERE, "mdi:flash",
                    SensorDeviceClass.CURRENT, SensorStateClass.MEASUREMENT],
-    "METER_L1_KW": ["p1_kw", "Leg 1 KW", POWER_KILO_WATT, "mdi:flash",
+    "METER_L1_KW": ["p1_kw", "Leg 1 KW", UnitOfPower.KILO_WATT, "mdi:flash",
                     SensorDeviceClass.POWER, SensorStateClass.MEASUREMENT],
-    "METER_L2_KW": ["p2_kw", "Leg 2 KW", POWER_KILO_WATT, "mdi:flash",
+    "METER_L2_KW": ["p2_kw", "Leg 2 KW", UnitOfPower.KILO_WATT, "mdi:flash",
                     SensorDeviceClass.POWER, SensorStateClass.MEASUREMENT],
-    "METER_L1_V": ["v1n_v", "Leg 1 Volts", ELECTRIC_POTENTIAL_VOLT, "mdi:flash",
+    "METER_L1_V": ["v1n_v", "Leg 1 Volts", UnitOfElectricPotential.VOLT, "mdi:flash",
                    SensorDeviceClass.VOLTAGE, SensorStateClass.MEASUREMENT],
-    "METER_L2_V": ["v2n_v", "Leg 2 Volts", ELECTRIC_POTENTIAL_VOLT, "mdi:flash",
+    "METER_L2_V": ["v2n_v", "Leg 2 Volts", UnitOfElectricPotential.VOLT, "mdi:flash",
                    SensorDeviceClass.VOLTAGE, SensorStateClass.MEASUREMENT],
-    "METER_L12_V": ["v12_v", "Supply Volts", ELECTRIC_POTENTIAL_VOLT, "mdi:flash",
+    "METER_L12_V": ["v12_v", "Supply Volts", UnitOfElectricPotential.VOLT, "mdi:flash",
                     SensorDeviceClass.VOLTAGE, SensorStateClass.MEASUREMENT],
-    "METER_TO_GRID": ["neg_ltea_3phsum_kwh", "KWH To Grid", ENERGY_KILO_WATT_HOUR, "mdi:flash",
+    "METER_TO_GRID": ["neg_ltea_3phsum_kwh", "KWH To Grid", UnitOfEnergy.KILO_WATT_HOUR, "mdi:flash",
                       SensorDeviceClass.ENERGY, SensorStateClass.TOTAL],
-    "METER_TO_HOME": ["pos_ltea_3phsum_kwh", "KWH To Home", ENERGY_KILO_WATT_HOUR, "mdi:flash",
+    "METER_TO_HOME": ["pos_ltea_3phsum_kwh", "KWH To Home", UnitOfEnergy.KILO_WATT_HOUR, "mdi:flash",
                       SensorDeviceClass.ENERGY, SensorStateClass.TOTAL_INCREASING]
 }
 
@@ -79,34 +79,34 @@ INVERTER_SENSORS = {
     "INVERTER_NET_KWH": [
         "ltea_3phsum_kwh",
         "Lifetime Power",
-        ENERGY_KILO_WATT_HOUR,
+        UnitOfEnergy.KILO_WATT_HOUR,
         "mdi:flash",
         SensorDeviceClass.ENERGY,
         SensorStateClass.TOTAL_INCREASING
     ],
-    "INVERTER_KW": ["p_3phsum_kw", "Power", POWER_KILO_WATT, "mdi:flash",
+    "INVERTER_KW": ["p_3phsum_kw", "Power", UnitOfPower.KILO_WATT, "mdi:flash",
                     SensorDeviceClass.POWER, SensorStateClass.MEASUREMENT],
-    "INVERTER_VOLTS": ["vln_3phavg_v", "Voltage", ELECTRIC_POTENTIAL_VOLT, "mdi:flash",
+    "INVERTER_VOLTS": ["vln_3phavg_v", "Voltage", UnitOfElectricPotential.VOLT, "mdi:flash",
                        SensorDeviceClass.VOLTAGE, SensorStateClass.MEASUREMENT],
-    "INVERTER_AMPS": ["i_3phsum_a", "Amps", ELECTRIC_CURRENT_AMPERE, "mdi:flash",
+    "INVERTER_AMPS": ["i_3phsum_a", "Amps", UnitOfElectricCurrent.AMPERE, "mdi:flash",
                       SensorDeviceClass.CURRENT, SensorStateClass.MEASUREMENT],
-    "INVERTER_MPPT_KW": ["p_mpptsum_kw", "MPPT KW", POWER_KILO_WATT, "mdi:flash",
+    "INVERTER_MPPT_KW": ["p_mpptsum_kw", "MPPT KW", UnitOfPower.KILO_WATT, "mdi:flash",
                          SensorDeviceClass.POWER, SensorStateClass.MEASUREMENT],
-    "INVERTER_MPPT1_KW": ["p_mppt1_kw", "MPPT KW", POWER_KILO_WATT, "mdi:flash",
+    "INVERTER_MPPT1_KW": ["p_mppt1_kw", "MPPT KW", UnitOfPower.KILO_WATT, "mdi:flash",
                           SensorDeviceClass.POWER, SensorStateClass.MEASUREMENT],
-    "INVERTER_MPPT_V": ["v_mppt1_v", "MPPT Volts", ELECTRIC_POTENTIAL_VOLT, "mdi:flash",
+    "INVERTER_MPPT_V": ["v_mppt1_v", "MPPT Volts", UnitOfElectricPotential.VOLT, "mdi:flash",
                         SensorDeviceClass.VOLTAGE, SensorStateClass.MEASUREMENT],
-    "INVERTER_MPPT_A": ["i_mppt1_a", "MPPT Amps", ELECTRIC_CURRENT_AMPERE, "mdi:flash",
+    "INVERTER_MPPT_A": ["i_mppt1_a", "MPPT Amps", UnitOfElectricCurrent.AMPERE, "mdi:flash",
                         SensorDeviceClass.CURRENT, SensorStateClass.MEASUREMENT],
     "INVERTER_TEMPERATURE": [
         "t_htsnk_degc",
         "Temperature",
-        TEMP_CELSIUS,
+        UnitOfTemperature.CELSIUS,
         "mdi:thermometer",
         SensorDeviceClass.TEMPERATURE,
         SensorStateClass.MEASUREMENT
     ],
-    "INVERTER_FREQUENCY": ["freq_hz", "Frequency", FREQUENCY_HERTZ, "mdi:flash",
+    "INVERTER_FREQUENCY": ["freq_hz", "Frequency", UnitOfFrequency.HERTZ, "mdi:flash",
                            None, SensorStateClass.MEASUREMENT],
 }
 
@@ -146,7 +146,7 @@ PVS_SENSORS = {
     "PVS_SCAN_TIME": [
         "dl_scan_time",
         "Scan Time",
-        TIME_SECONDS,
+        UnitOfTime.SECONDS,
         "mdi:timer-outline",
         None,
         SensorStateClass.MEASUREMENT
@@ -162,7 +162,7 @@ PVS_SENSORS = {
     "PVS_UPTIME": [
         "dl_uptime",
         "Uptime",
-        TIME_SECONDS,
+        UnitOfTime.SECONDS,
         "mdi:timer-outline",
         None,
         SensorStateClass.TOTAL_INCREASING
@@ -170,7 +170,7 @@ PVS_SENSORS = {
     "PVS_MEMORY_USED": [
         "dl_mem_used",
         "Memory Used",
-        DATA_KILOBYTES,
+        UnitOfInformation.KILOBYTES,
         "mdi:memory",
         None,
         SensorStateClass.MEASUREMENT
@@ -178,7 +178,7 @@ PVS_SENSORS = {
     "PVS_FLASH_AVAILABLE": [
         "dl_flash_avail",
         "Flash Available",
-        DATA_KILOBYTES,
+        UnitOfInformation.KILOBYTES,
         "mdi:memory",
         None,
         SensorStateClass.MEASUREMENT


### PR DESCRIPTION
Fixes #55 

should fix errors of this sort in logs:
Logger: homeassistant.const
Source: helpers/deprecation.py:206
First occurred: 4:19:55 PM (11 occurrences)
Last logged: 4:19:57 PM

ELECTRIC_POTENTIAL_VOLT was used from sunpower, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfElectricPotential.VOLT instead, please report it to the author of the 'sunpower' custom integration
ELECTRIC_CURRENT_AMPERE was used from sunpower, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfElectricCurrent.AMPERE instead, please report it to the author of the 'sunpower' custom integration
TEMP_CELSIUS was used from sunpower, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfTemperature.CELSIUS instead, please report it to the author of the 'sunpower' custom integration