### PR TITLE
Fix potential div zero error in init

### DIFF
--- a/custom_components/sunpower/__init__.py
+++ b/custom_components/sunpower/__init__.py
@@ -71,8 +71,8 @@ def create_vmeter(data):
         if "vln_3phavg_v" in inverter:
             volts.append(float(inverter["vln_3phavg_v"]))
 
-    freq_avg = sum(freq) / len(freq) if len(freq) > 0 else 60
-    volts_avg = sum(volts) / len(volts) if len(volts) > 0 else 210
+    freq_avg = sum(freq) / len(freq) if len(freq) > 0 else None
+    volts_avg = sum(volts) / len(volts) if len(volts) > 0 else None
 
     pvs_serial = next(iter(data[PVS_DEVICE_TYPE]))  # only one PVS
     vmeter_serial = f"{pvs_serial}pv"

--- a/custom_components/sunpower/__init__.py
+++ b/custom_components/sunpower/__init__.py
@@ -71,8 +71,8 @@ def create_vmeter(data):
         if "vln_3phavg_v" in inverter:
             volts.append(float(inverter["vln_3phavg_v"]))
 
-    freq_avg = sum(freq) / len(freq)
-    volts_avg = sum(volts) / len(volts)
+    freq_avg = sum(freq) / len(freq) if len(freq) > 0 else 60
+    volts_avg = sum(volts) / len(volts) if len(volts) > 0 else 210
 
     pvs_serial = next(iter(data[PVS_DEVICE_TYPE]))  # only one PVS
     vmeter_serial = f"{pvs_serial}pv"


### PR DESCRIPTION
Wraps math function inside ternary operator to provide for a "default" value when actual values are not available.

I suspect this happens when the virtual meter device is created during local night, when the inverters are in an error state, and associated entites are unavailable.