### PR TITLE
varnish port update

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,9 @@ A detailed setup using a Raspberry Pi which fits into the PVS is [available here
 Instead of setting up an `haproxy` server as detailed in the guide, you may want to install a
 `varnish` server and cache the PVS output, reducing the risk of firmware issues described in
 the warning above. `sudo apt-get install varnish`, then use the `default.vcl`
-[available here](contrib/varnish/default.vcl), which will cache PVS output for 10 minutes.
+[available here](contrib/varnish/default.vcl), along with
+`override.conf` [available here](contrib/varnish/override.conf) which will cache PVS output for
+10 minutes.
 
 ## Devices
 

--- a/contrib/varnish/override.conf
+++ b/contrib/varnish/override.conf
@@ -1,0 +1,16 @@
+# This file overrides the default varnish port of 6081 so the more typical
+# port 80 is used.
+#
+# Put this file into:
+#  /etc/systemd/system/varnish.service.d/
+#
+[Service]
+ExecStart=
+ExecStart=/usr/sbin/varnishd \
+          -j unix,user=vcache \
+          -F \
+          -a :80 \
+          -T localhost:6082 \
+          -f /etc/varnish/default.vcl \
+          -S /etc/varnish/secret \
+          -s malloc,256m


### PR DESCRIPTION
Add 'override.conf' for varnish config so it will run on expected port 80, and associated README update